### PR TITLE
[CY-10909] Add support for Hebrew keyboard layout

### DIFF
--- a/src/protocols/rdp/Makefile.am
+++ b/src/protocols/rdp/Makefile.am
@@ -252,7 +252,8 @@ rdp_keymaps =                                \
     $(srcdir)/keymaps/ro_ro_qwerty.keymap    \
     $(srcdir)/keymaps/sv_se_qwerty.keymap    \
     $(srcdir)/keymaps/da_dk_qwerty.keymap    \
-    $(srcdir)/keymaps/tr_tr_qwerty.keymap
+    $(srcdir)/keymaps/tr_tr_qwerty.keymap    \
+    $(srcdir)/keymaps/he_il_qwerty.keymap
 
 _generated_keymaps.c: $(rdp_keymaps) $(srcdir)/keymaps/generate.pl
 	$(AM_V_GEN) $(srcdir)/keymaps/generate.pl $(rdp_keymaps)

--- a/src/protocols/rdp/keymaps/he_il_qwerty.keymap
+++ b/src/protocols/rdp/keymaps/he_il_qwerty.keymap
@@ -1,0 +1,3 @@
+parent  "base"
+name    "he-il-qwerty"
+freerdp "KBD_HEBREW"


### PR DESCRIPTION
Adding support for Hebrew keyboard layout.
Up until now, we didn't support Hebrew layout

The keymap file I added inherits the base keymap file called "base"
Other keyboard layouts messed up the Hebrew keyboard (such as the English one), so we needed to add a specific layout for Hebrew.


