### PR TITLE
[CY-18409] guacd APK fixes: RDP plugin path and SSH font bundling for launcher

### DIFF
--- a/apk/APKBUILD
+++ b/apk/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Cyolo <support@cyolo.io>
 pkgname=guacd
-pkgver=1.5.5.3
+pkgver=1.5.5.4
 pkgrel=0
 pkgdesc="Apache Guacamole proxy daemon (Cyolo build with bundled dependencies)"
 url="https://guacamole.apache.org/"

--- a/apk/APKBUILD
+++ b/apk/APKBUILD
@@ -8,7 +8,7 @@ arch="aarch64 x86_64"
 license="Apache-2.0"
 depends=""
 makedepends=""
-source="guacamole.tar.gz bundled-libs.tar.gz entrypoint.sh"
+source="guacamole.tar.gz bundled-libs.tar.gz fonts.tar.gz entrypoint.sh"
 options="!check !tracedeps !strip net"
 
 # Installation path follows same pattern as IDAC: /software/{component}/{version}/
@@ -45,6 +45,14 @@ package() {
         cp "$srcdir/bundled-libs"/* "$pkgdir$_prefix/lib/"
     else
         echo "   Warning: No bundled libraries found - package may not be portable!"
+    fi
+    
+    # Install fonts for SSH/telnet terminal rendering
+    if [ -d "$srcdir/fonts/share/fonts" ]; then
+        install -dm755 "$pkgdir$_prefix/share/fonts"
+        cp -r "$srcdir/fonts/share/fonts/"* "$pkgdir$_prefix/share/fonts/"
+        font_count=$(find "$pkgdir$_prefix/share/fonts" -name "*.ttf" | wc -l)
+        echo "   Installed $font_count font files"
     fi
     
     # Install entrypoint wrapper (sets LD_LIBRARY_PATH)

--- a/apk/build-apk.sh
+++ b/apk/build-apk.sh
@@ -160,6 +160,15 @@ else
     echo "   Successfully copied $dep_count out of $NUM_DEPS libraries"
 fi
 
+# Extract fonts for bundling (SSH/telnet terminal rendering needs them)
+echo ""
+echo "Extracting fonts for bundling..."
+mkdir -p "$EXTRACT_DIR/fonts"
+docker exec "$DEPS_CONTAINER" sh -c 'tar -cf - /usr/share/fonts/dejavu/ /etc/fonts/fonts.conf 2>/dev/null' \
+    | tar -xf - -C "$EXTRACT_DIR/fonts/" --strip-components=1 2>/dev/null || true
+FONT_COUNT=$(find "$EXTRACT_DIR/fonts" -name "*.ttf" 2>/dev/null | wc -l)
+echo "   Extracted $FONT_COUNT font files"
+
 # Cleanup deps container
 docker stop "$DEPS_CONTAINER" > /dev/null
 docker rm "$DEPS_CONTAINER" > /dev/null
@@ -182,6 +191,7 @@ mkdir -p "$BUILD_DIR"
 # Create tarballs for APK sources
 tar -czf "$BUILD_DIR/guacamole.tar.gz" -C "$EXTRACT_DIR" guacamole
 tar -czf "$BUILD_DIR/bundled-libs.tar.gz" -C "$EXTRACT_DIR" bundled-libs
+tar -czf "$BUILD_DIR/fonts.tar.gz" -C "$EXTRACT_DIR" fonts
 
 # Copy APKBUILD and entrypoint
 cp "$SCRIPT_DIR/APKBUILD" "$BUILD_DIR/"

--- a/apk/build-apk.sh
+++ b/apk/build-apk.sh
@@ -55,10 +55,14 @@ if ! docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "^$DOCKER_IMAGE
     echo "   Platform: $DOCKER_PLATFORM"
     echo "   This will compile guacd and all dependencies (~5-10 minutes)"
     cd "$GUACAMOLE_SERVER_DIR"
+    # Override PREFIX_DIR so FreeRDP's compiled-in plugin path matches the
+    # launcher's runtime path (/host/cyolo/software/guacd is a stable symlink
+    # maintained by the launcher pointing to the versioned install directory).
     docker buildx build -t "$DOCKER_IMAGE" \
         --platform "$DOCKER_PLATFORM" \
         --target builder \
         --build-arg ALPINE_BASE_IMAGE=3.18.6 \
+        --build-arg PREFIX_DIR=/host/cyolo/software/guacd \
         --load \
         -f Dockerfile \
         . || { echo "ERROR: Docker build failed"; exit 1; }
@@ -90,9 +94,10 @@ trap cleanup EXIT
 echo "Extracting guacd artifacts..."
 mkdir -p "$EXTRACT_DIR/bundled-libs"
 
-# Extract /opt/guacamole from the image
+# Extract build artifacts from the image (PREFIX_DIR=/host/cyolo/software/guacd)
+# Rename to "guacamole" locally so the rest of the script and APKBUILD work unchanged.
 CONTAINER_ID=$(docker create "$DOCKER_IMAGE")
-docker cp "$CONTAINER_ID:/opt/guacamole" "$EXTRACT_DIR/"
+docker cp "$CONTAINER_ID:/host/cyolo/software/guacd" "$EXTRACT_DIR/guacamole"
 docker rm "$CONTAINER_ID" > /dev/null
 
 echo "Artifacts extracted"

--- a/apk/entrypoint.sh
+++ b/apk/entrypoint.sh
@@ -13,7 +13,7 @@ export LC_ALL=C.UTF-8
 
 # Configure fontconfig to use bundled fonts (needed for SSH/telnet terminal rendering).
 # Generate a minimal config at runtime so the font directory path is always correct.
-if [ -d "${INSTALL_DIR}/share/fonts" ] && [ ! -f /tmp/guacd-fonts.conf ]; then
+if [ -d "${INSTALL_DIR}/share/fonts" ]; then
     cat > /tmp/guacd-fonts.conf <<FONTCONF
 <?xml version="1.0"?>
 <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">

--- a/apk/entrypoint.sh
+++ b/apk/entrypoint.sh
@@ -11,6 +11,22 @@ INSTALL_DIR="$(dirname "$SCRIPT_DIR")"
 export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${LD_LIBRARY_PATH}"
 export LC_ALL=C.UTF-8
 
+# Configure fontconfig to use bundled fonts (needed for SSH/telnet terminal rendering).
+# Generate a minimal config at runtime so the font directory path is always correct.
+if [ -d "${INSTALL_DIR}/share/fonts" ] && [ ! -f /tmp/guacd-fonts.conf ]; then
+    cat > /tmp/guacd-fonts.conf <<FONTCONF
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+    <dir>${INSTALL_DIR}/share/fonts</dir>
+    <match target="pattern">
+        <edit name="family" mode="append_last"><string>DejaVu Sans Mono</string></edit>
+    </match>
+</fontconfig>
+FONTCONF
+fi
+export FONTCONFIG_FILE="${FONTCONFIG_FILE:-/tmp/guacd-fonts.conf}"
+
 # Default configuration
 GUACD_LOG_LEVEL="${GUACD_LOG_LEVEL:-info}"
 GUAC_LISTEN_PORT="${GUAC_LISTEN_PORT:-4822}"

--- a/apk/entrypoint.sh
+++ b/apk/entrypoint.sh
@@ -19,9 +19,18 @@ if [ -d "${INSTALL_DIR}/share/fonts" ] && [ ! -f /tmp/guacd-fonts.conf ]; then
 <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
 <fontconfig>
     <dir>${INSTALL_DIR}/share/fonts</dir>
-    <match target="pattern">
-        <edit name="family" mode="append_last"><string>DejaVu Sans Mono</string></edit>
-    </match>
+    <alias>
+        <family>monospace</family>
+        <prefer><family>DejaVu Sans Mono</family></prefer>
+    </alias>
+    <alias>
+        <family>sans-serif</family>
+        <prefer><family>DejaVu Sans</family></prefer>
+    </alias>
+    <alias>
+        <family>serif</family>
+        <prefer><family>DejaVu Serif</family></prefer>
+    </alias>
 </fontconfig>
 FONTCONF
 fi


### PR DESCRIPTION
## Summary

Fixes two protocol-level failures when guacd runs as an APK under the launcher (instead of Docker):

- **RDP: UPSTREAM_UNAVAILABLE [520]** — FreeRDP bakes the plugin path from `CMAKE_INSTALL_PREFIX` into the binary at compile time. The Docker build used `/opt/guacamole`, but the launcher installs to `/host/cyolo/software/guacd`. Override `PREFIX_DIR` in `build-apk.sh` so the compiled-in path matches the launcher's stable symlink.
- **SSH: "Unable to load font monospace"** — The terminal emulator needs fontconfig + DejaVu fonts. Bundle them in the APK and generate a minimal fontconfig at runtime with proper generic family aliases (monospace → DejaVu Sans Mono).

Jira: CY-18409

## Changes

- `apk/build-apk.sh` — Override `PREFIX_DIR` build arg; extract DejaVu fonts from deps container; create `fonts.tar.gz` source
- `apk/APKBUILD` — Add `fonts.tar.gz` source; install fonts to `share/fonts/` in package
- `apk/entrypoint.sh` — Generate fontconfig at runtime with font directory and generic family aliases

## Test plan

- [x] Build APK locally, extract, verify fonts present under `share/fonts/dejavu/`
- [x] Install APK via launcher, connect to RDP application — works
- [x] Install APK via launcher, connect to SSH application — works
- [x] Rebuild APK on GitHub CI, install fresh via launcher boot cycle — both RDP and SSH work

Made with [Cursor](https://cursor.com)